### PR TITLE
Configure SCA workflow to run on main branch

### DIFF
--- a/.github/workflows/02-sca.yaml
+++ b/.github/workflows/02-sca.yaml
@@ -1,6 +1,10 @@
 name: 02-sca
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 # Cancel previous runs if a new commit is pushed to the same PR
 concurrency:


### PR DESCRIPTION
## Summary
- Enable SCA workflow to run on both pull requests and pushes to main branch
- Allows continuous vulnerability monitoring in the main branch

## Test plan
- [ ] Verify workflow runs on PR
- [ ] Verify workflow runs on push to main after merge
- [ ] Confirm SBOM generation and upload to Dependency Track
- [ ] Confirm vulnerability scanning and SARIF upload to Code Scanning
- [ ] Confirm GitHub Dependency Graph integration